### PR TITLE
GCC and Clang compatibility

### DIFF
--- a/ChannelsCPP/Channel.h
+++ b/ChannelsCPP/Channel.h
@@ -22,7 +22,7 @@ namespace go
 	public:
 		Chan()
 		{
-			IChan::m_buffer = OChan::m_buffer = std::make_shared<internal::ChannelBuffer<T, Buffer_Size>>();
+			Chan::IChan::m_buffer = Chan::OChan::m_buffer = std::make_shared<internal::ChannelBuffer<T, Buffer_Size>>();
 			//IChan<T, Buffer_Size>::m_buffer = OChan<T, Buffer_Size>::m_buffer = std::make_shared<internal::ChannelBuffer<T, Buffer_Size>>();
 		}
 		~Chan() = default;

--- a/ChannelsCPP/Channel.h
+++ b/ChannelsCPP/Channel.h
@@ -28,15 +28,15 @@ namespace go
 		~Chan() = default;
 
 		//Insert in channel
-		friend 	OChan<T, Buffer_Size> operator<<(Chan<T, Buffer_Size>& ch, const T& obj)
+		friend 	OChan<T, Buffer_Size>& operator<<(Chan<T, Buffer_Size>& ch, const T& obj)
 		{
-			return static_cast<OChan<T, Buffer_Size>>(ch) << obj;
+			return static_cast<OChan<T, Buffer_Size>&>(ch) << obj;
 			/*ch.m_buffer->insertValue(obj);
 			return ch;*/
 		}
-		friend 	OChan<T, Buffer_Size> operator >> (const T& obj, Chan<T, Buffer_Size>& ch)
+		friend 	OChan<T, Buffer_Size>& operator >> (const T& obj, Chan<T, Buffer_Size>& ch)
 		{
-			return static_cast<OChan<T, Buffer_Size>>(ch) << obj;
+			return static_cast<OChan<T, Buffer_Size>&>(ch) << obj;
 
 			/*ch.m_buffer->insertValue(obj);
 			return  ch;*/
@@ -45,11 +45,11 @@ namespace go
 		//Stream
 		friend std::ostream& operator<<(std::ostream& os, Chan<T, Buffer_Size>& ch)
 		{
-			return os << static_cast<OChan<T, Buffer_Size>>(ch);
+			return os << static_cast<OChan<T, Buffer_Size>&>(ch);
 		}
 		friend std::istream& operator >> (std::istream& is, Chan<T, Buffer_Size>& ch)
 		{
-			return is >> static_cast<IChan<T, Buffer_Size>>(ch);
+			return is >> static_cast<IChan<T, Buffer_Size>&>(ch);
 		}
 
 

--- a/ChannelsCPP/ChannelUtility.h
+++ b/ChannelsCPP/ChannelUtility.h
@@ -110,7 +110,8 @@ namespace go
 		template<typename ...T>
 		void exec(Default && c, T &&... params)
 		{
-			static_assert(false, "There should only be at most 1 Default case and it must be the last parameter of the Select");
+			// Always false
+			static_assert(static_cast<long long>(sizeof...(params)) == -1, "There should only be at most 1 Default case and it must be the last parameter of the Select");
 		}
 
 	public:

--- a/ChannelsCPP/ChannelUtility.h
+++ b/ChannelsCPP/ChannelUtility.h
@@ -11,6 +11,11 @@
 
 namespace go
 {
+	namespace internal
+	{
+		template<typename...> constexpr bool dependent_false = false;
+	}
+	
 	template<typename T, std::size_t Buffer_Size> class Chan;
 
 	template<typename T, std::size_t Buffer_Size> class OChan;
@@ -110,8 +115,7 @@ namespace go
 		template<typename ...T>
 		void exec(Default && c, T &&... params)
 		{
-			// Always false
-			static_assert(static_cast<long long>(sizeof...(params)) == -1, "There should only be at most 1 Default case and it must be the last parameter of the Select");
+			static_assert(internal::dependent_false<T...>, "There should only be at most 1 Default case and it must be the last parameter of the Select");
 		}
 
 	public:

--- a/ChannelsCPP/Circular_buffer.h
+++ b/ChannelsCPP/Circular_buffer.h
@@ -76,7 +76,7 @@ namespace go
 			{
 				if (empty())
 					throw std::out_of_range("container is empty");
-				return *m_end
+				return *m_end;
 			}
 
 			syze_type size() const


### PR DESCRIPTION
This pull request adds Clang and GCC compatibility. Three main changes has been done to do so:

 - Added `&` in return types and static casts, avoiding binding lvalue references to temporaries
 - Fixed static assert to use a dependent expression
 - Fixed uses of [injected base class name in templates](https://stackoverflow.com/questions/43712270/compiler-error-when-calling-base-constructor-when-both-base-and-derived-are-temp)

The next step should be to provide a CMakeLists instead of a sln. Visual Studio already supports CMake projects since VS 2017. 